### PR TITLE
[ENH] Change color tone of selected component to show it is selected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tedana-reports",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rica",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",


### PR DESCRIPTION
Closes #8 .

This PR makes the following changes:
- Now, when a component is selected, its color is changed to a darker tone until a different component is selected. This helps identify the component in the scatter and pie plots.
- Plots are now fed data through `state`, which sets the foundation for updating plots with a manual classification.