### PR TITLE
[ENH] Added pan option to scatter plots

### DIFF
--- a/src/Plots/PlotOptions.js
+++ b/src/Plots/PlotOptions.js
@@ -71,6 +71,11 @@ export const options_kappa_rho = {
         x: { min: "original", max: "original" },
         y: { min: "original", max: "original" },
       },
+      pan: {
+        enabled: true,
+        mode: "xy",
+        modifierKey: "shift",
+      },
     },
   },
 };
@@ -145,6 +150,11 @@ export const options_rho = {
         x: { min: "original", max: "original" },
         y: { min: "original", max: "original" },
       },
+      pan: {
+        enabled: true,
+        mode: "xy",
+        modifierKey: "shift",
+      },
     },
   },
 };
@@ -218,6 +228,11 @@ export const options_kappa = {
       limits: {
         x: { min: "original", max: "original" },
         y: { min: "original", max: "original" },
+      },
+      pan: {
+        enabled: true,
+        mode: "xy",
+        modifierKey: "shift",
       },
     },
   },


### PR DESCRIPTION
Closes #29 

This PR adds `pan` functionality to scatter plots. In order to move around the plot, users have to click `shift` and use the mouse.