### PR TITLE
Deal with rationale if it exists instead of of classification tags

### DIFF
--- a/src/Plots/Plots.js
+++ b/src/Plots/Plots.js
@@ -201,6 +201,10 @@ class Plots extends React.Component {
       if (origData[i].classification !== origData[i].original_classification) {
         origData[i].classification_tags =
           origData[i].classification_tags + ", Manual reclassify with Rica";
+        // If origData has "rationale", then add "I001" to it
+        if (origData[i].rationale) {
+          origData[i].rationale = "I001";
+        }
       }
     }
 
@@ -225,16 +229,18 @@ class Plots extends React.Component {
     for (var i = 0; i < origData.length; i++) {
       // If classification is accepted and classification_tags has "Manual reclassify with Rica"
       if (
-        origData[i].classification === "accepted" &&
-        origData[i].classification_tags.includes("Manual reclassify with Rica")
+        (origData[i].classification === "accepted" &&
+          origData[i].classification_tags.includes("Manual reclassify with Rica"))
+        || (origData[i].rationale == "I001")
       ) {
         accepted.push(i);
       }
 
       // If classification is rejected and classification_tags has "Manual reclassify with Rica"
       if (
-        origData[i].classification === "rejected" &&
-        origData[i].classification_tags.includes("Manual reclassify with Rica")
+        (origData[i].classification === "rejected" &&
+          origData[i].classification_tags.includes("Manual reclassify with Rica"))
+        || (origData[i].rationale == "I001")
       ) {
         rejected.push(i);
       }


### PR DESCRIPTION
Closes #61.

This PR adds a couple of `if` statements that allow adding and exporting manual classifications based on `rationale` instead of `classification_tags` when the former exists in the file.