### PR TITLE
fix: Fix inline build, BIDS server loading, and bump version to 2.1.6

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ function inlineAssets() {
       inlinesource({
         compress: false,
         ignore: ["png"],
+        rootpath: "build",
       })
     )
     .pipe(dest("./build"));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "rica",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
+  "proxy": "http://localhost:8000",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/scripts/rica_server.py
+++ b/scripts/rica_server.py
@@ -167,7 +167,7 @@ def main():
 
     # Start server
     try:
-        with http.server.HTTPServer(("", args.port), RicaHandler) as httpd:
+        with http.server.ThreadingHTTPServer(("", args.port), RicaHandler) as httpd:
             url = f"http://localhost:{args.port}"
             print(f"Rica server running at {url}")
             print(f"Serving files from: {cwd}")

--- a/src/PopUps/IntroPopUp.js
+++ b/src/PopUps/IntroPopUp.js
@@ -141,14 +141,14 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
         (f) =>
           f.includes("comp_") ||
           f.includes(".svg") ||
-          f === "report.txt" ||
+          f.endsWith("report.txt") ||
           (f.includes("_metrics.tsv") && !f.toLowerCase().includes("pca")) ||
-          (f.startsWith("tedana_20") && f.endsWith(".tsv")) ||
+          (f.startsWith("tedana_20") || f.endsWith("_tedana_log.tsv")) ||
           (f.includes("_mixing.tsv") && !f.toLowerCase().includes("pca") && !f.toLowerCase().includes("orth")) ||
           (f.includes("_components.nii.gz") && f.toLowerCase().includes("ica") && !f.includes("stat-z") && !f.includes("echo-")) ||
           f === "betas_OC.nii.gz" ||
           f.includes("_mask.nii") ||
-          f.includes("CrossComponent_metrics.json") ||
+          (f.includes("CrossComponent_metrics.json") && !f.toLowerCase().includes("pca")) ||
           (f.includes("cross_component_metrics.json") && !f.toLowerCase().includes("pca")) ||
           f === "manual_classification.tsv" ||
           // QC NIfTI files
@@ -190,8 +190,9 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
       // Repetition time from registry
       let repetitionTime = null;
 
-      // Process files via HTTP fetch
-      for (const filepath of relevantFiles) {
+      // Process files via HTTP fetch (parallel)
+      try {
+      const filePromises = relevantFiles.map(async (filepath) => {
         const filename = filepath.split("/").pop();
 
         try {
@@ -221,7 +222,7 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
           }
 
           // Report info
-          if (filename === "report.txt") {
+          if (filename.endsWith("report.txt")) {
             const response = await fetch(`/${filepath}`);
             info = await response.text();
             setLoadingProgress((prev) => ({ ...prev, current: prev.current + 1 }));
@@ -243,7 +244,7 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
           }
 
           // Dataset path
-          if (filename.startsWith("tedana_20") && filename.endsWith(".tsv")) {
+          if (filename.startsWith("tedana_20") || filename.endsWith("_tedana_log.tsv")) {
             const response = await fetch(`/${filepath}`);
             const text = await response.text();
             const lines = text.split("\n");
@@ -271,12 +272,14 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
           if ((filename.includes("_components.nii.gz") && filename.toLowerCase().includes("ica") && !filename.includes("stat-z") && !filename.includes("echo-")) || filename === "betas_OC.nii.gz") {
             // Extract TR from NIfTI header using a Range request (first 4KB is enough to
             // decompress the header from gzip), independent of loading the full file.
+            // Only trust 206 Partial Content — if the proxy doesn't forward Range headers,
+            // the server returns 200 with the full file, which would hang on arrayBuffer().
             if (!repetitionTime) {
               try {
                 const headerResponse = await fetch(`/${filepath}`, {
                   headers: { Range: "bytes=0-4095" },
                 });
-                if (headerResponse.ok || headerResponse.status === 206) {
+                if (headerResponse.status === 206) {
                   const headerBuffer = await headerResponse.arrayBuffer();
                   const tr = await extractTRFromNifti(headerBuffer);
                   if (tr) {
@@ -288,15 +291,9 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
                 // Range requests not supported; TR won't be extracted from header
               }
             }
-            // Always set URL so BrainViewer can load even if buffer fails
+            // Use URL — BrainViewer prefers URL over buffer anyway, and skipping the
+            // full download avoids hanging Promise.all on large files through the proxy.
             niftiUrl = `/${filepath}`;
-            // Also try loading the full buffer (fails gracefully for very large files)
-            try {
-              const response = await fetch(`/${filepath}`);
-              niftiBuffer = await response.arrayBuffer();
-            } catch {
-              console.warn("[Rica] NIfTI too large for ArrayBuffer, Niivue will load from URL");
-            }
             setLoadingProgress((prev) => ({ ...prev, current: prev.current + 1 }));
           }
 
@@ -308,7 +305,7 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
           }
 
           // Cross-component metrics (for elbow thresholds)
-          if (filename.includes("CrossComponent_metrics.json") ||
+          if ((filename.includes("CrossComponent_metrics.json") && !filename.toLowerCase().includes("pca")) ||
               (filename.includes("cross_component_metrics.json") && !filename.toLowerCase().includes("pca"))) {
             const response = await fetch(`/${filepath}`);
             crossComponentMetrics = await response.json();
@@ -385,7 +382,8 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
         } catch (error) {
           console.error(`Error fetching file ${filepath}:`, error);
         }
-      }
+      });
+      await Promise.all(filePromises);
 
       // Sort component figures by name
       compFigures.sort((a, b) => a.name.localeCompare(b.name));
@@ -419,6 +417,29 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
         statusTableData,
         repetitionTime,
       });
+      } catch (err) {
+        console.error("[Rica] loadFromServer failed:", err);
+        onDataLoad({
+          componentFigures: compFigures,
+          carpetFigures,
+          diagnosticFigures,
+          components: [components],
+          info,
+          originalData: [originalData],
+          dirPath,
+          mixingMatrix,
+          niftiBuffer,
+          niftiUrl,
+          maskBuffer,
+          crossComponentMetrics,
+          qcNiftiBuffers,
+          externalRegressorsFigure,
+          hasManualClassifications: manualClassificationData && manualClassificationData.length > 0,
+          decisionTreeData,
+          statusTableData,
+          repetitionTime,
+        });
+      }
     },
     [onDataLoad, onLoadingStart]
   );
@@ -457,15 +478,15 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
         (f) =>
           f.name.includes("comp_") ||
           f.name.includes(".svg") ||
-          f.name === "report.txt" ||
+          f.name.endsWith("report.txt") ||
           (f.name.includes("_metrics.tsv") && !f.name.toLowerCase().includes("pca")) ||
-          (f.name.startsWith("tedana_20") && f.name.endsWith(".tsv")) ||
+          (f.name.startsWith("tedana_20") || f.name.endsWith("_tedana_log.tsv")) ||
           // New files for Niivue integration
           (f.name.includes("_mixing.tsv") && !f.name.toLowerCase().includes("pca") && !f.name.toLowerCase().includes("orth")) ||
           (f.name.includes("_components.nii.gz") && f.name.toLowerCase().includes("ica") && !f.name.includes("stat-z") && !f.name.includes("echo-")) ||
           f.name === "betas_OC.nii.gz" ||
           f.name.includes("_mask.nii") ||
-          f.name.includes("CrossComponent_metrics.json") ||
+          (f.name.includes("CrossComponent_metrics.json") && !f.name.toLowerCase().includes("pca")) ||
           (f.name.includes("cross_component_metrics.json") && !f.name.toLowerCase().includes("pca")) ||
           f.name === "manual_classification.tsv" ||
           // QC NIfTI files
@@ -534,7 +555,7 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
           }
 
           // Report info
-          if (filename === "report.txt") {
+          if (filename.endsWith("report.txt")) {
             info = await readFileAsText(file);
             setLoadingProgress((prev) => ({ ...prev, current: prev.current + 1 }));
           }
@@ -554,7 +575,7 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
           }
 
           // Dataset path
-          if (filename.startsWith("tedana_20") && filename.endsWith(".tsv")) {
+          if (filename.startsWith("tedana_20") || filename.endsWith("_tedana_log.tsv")) {
             const text = await readFileAsText(file);
             // Look for the line containing "Using output directory:"
             const lines = text.split("\n");
@@ -607,7 +628,7 @@ function IntroPopup({ onDataLoad, onLoadingStart, closePopup, isLoading, isDark 
           }
 
           // Cross-component metrics (for elbow thresholds)
-          if (filename.includes("CrossComponent_metrics.json") ||
+          if ((filename.includes("CrossComponent_metrics.json") && !filename.toLowerCase().includes("pca")) ||
               (filename.includes("cross_component_metrics.json") && !filename.toLowerCase().includes("pca"))) {
             const text = await readFileAsText(file);
             crossComponentMetrics = JSON.parse(text);


### PR DESCRIPTION
## Summary

- **gulpfile.js**: Add `rootpath: "build"` to `gulp-inline-source` — fixes the core issue where the inline build silently failed (CSS/JS paths like `/static/css/main.*.css` were resolved relative to `process.cwd()` instead of `build/`), causing the released `index.html` to still reference external assets. When `open_rica_report.py` serves Rica at `/rica/index.html` those absolute paths 404. Now the build produces a true single-file HTML.
- **IntroPopUp.js**: Fix server loading for BIDS-named tedana output (report.txt matching, tedana log matching, parallel loading); fix Range request to only accept 206 to avoid hanging `Promise.all` through the CRA proxy; skip redundant NIfTI buffer download in server mode.
- **rica_server.py**: Switch to `ThreadingHTTPServer` for concurrent requests.
- **package.json**: Add `proxy` for `npm start` dev workflow; bump `2.1.5` → `2.1.6` so `open_rica_report.py` auto-updates.

## Test plan

- [ ] Run `npm run build:inline` and confirm `build/index.html` has no `<script src=` or `<link href=` pointing to `/static/`
- [ ] Verify Rica loads correctly when served from a subdirectory
- [ ] Confirm server auto-loading works with BIDS-named tedana output via `npm start` + `rica_server.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)