### PR TITLE
feat: Add component sorting by any metric in metrics.tsv

### DIFF
--- a/src/Plots/ComponentTable.js
+++ b/src/Plots/ComponentTable.js
@@ -46,56 +46,62 @@ function getColumnLabel(key) {
     "classification_tags": "Tags",
     "kappa rank": "κ Rank",
     "rho rank": "ρ Rank",
+    "variance explained rank": "VE Rank",
     "rationale": "Rationale",
   };
   return labels[key] || key;
 }
 
-// Columns to display (in order)
-const DISPLAY_COLUMNS = [
+// Preferred column order — known columns first, then any extras from the TSV
+const PRIORITY_COLUMNS = [
   "Component",
   "kappa",
   "rho",
   "variance explained",
+  "normalized variance explained",
   "kappa rank",
   "rho rank",
+  "variance explained rank",
   "dice_FT2",
   "dice_FS0",
+  "countsigFT2",
+  "countsigFS0",
   "signal-noise_t",
+  "signal-noise_p",
+  "optimal sign",
   "classification",
   "classification_tags",
+  "rationale",
 ];
 
 function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDark = false, isCollapsed = false, onToggleCollapse, sortColumn = '', sortDirection = 'desc', onSort, sortedIndices }) {
   const selectedRowRef = useRef(null);
   const tableContainerRef = useRef(null);
 
-  // Scroll selected row into view when selection changes (only if not collapsed)
+  // Scroll selected row into view within the table container only (don't scroll the page)
   useEffect(() => {
-    if (isCollapsed) return; // Don't auto-scroll when collapsed
+    if (isCollapsed) return;
     if (selectedRowRef.current && tableContainerRef.current) {
       const container = tableContainerRef.current;
       const row = selectedRowRef.current;
-
-      // Calculate if row is visible in the container
       const containerRect = container.getBoundingClientRect();
       const rowRect = row.getBoundingClientRect();
-
-      // Check if row is outside visible area
       if (rowRect.top < containerRect.top || rowRect.bottom > containerRect.bottom) {
-        row.scrollIntoView({
-          behavior: "smooth",
-          block: "center",
-        });
+        const targetScrollTop =
+          row.offsetTop - container.clientHeight / 2 + row.offsetHeight / 2;
+        container.scrollTo({ top: targetScrollTop, behavior: "smooth" });
       }
     }
   }, [selectedIndex, isCollapsed]);
 
-  // Determine which columns exist in the data
+  // Show all columns: priority-ordered known columns first, then any extras from the TSV
   const columns = useMemo(() => {
     if (!data?.length) return [];
-    const availableKeys = Object.keys(data[0]);
-    return DISPLAY_COLUMNS.filter((col) => availableKeys.includes(col));
+    const availableKeys = new Set(Object.keys(data[0]));
+    const priorityVisible = PRIORITY_COLUMNS.filter((col) => availableKeys.has(col));
+    const prioritySet = new Set(priorityVisible);
+    const extra = Object.keys(data[0]).filter((col) => !prioritySet.has(col));
+    return [...priorityVisible, ...extra];
   }, [data]);
 
   if (!data?.length) {

--- a/src/Plots/ComponentTable.js
+++ b/src/Plots/ComponentTable.js
@@ -225,30 +225,60 @@ function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDa
             <tr>
               {columns.map((col) => {
                 const isActive = sortColumn === col;
+                const textAlign = col === "Component" || col === "classification" || col === "classification_tags" ? 'left' : 'right';
+                const ariaSort = isActive ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none';
                 return (
                   <th
                     key={col}
-                    onClick={() => onSort?.(col)}
+                    aria-sort={ariaSort}
                     style={{
                       padding: '12px',
                       fontWeight: 600,
                       whiteSpace: 'nowrap',
-                      textAlign: col === "Component" || col === "classification" || col === "classification_tags" ? 'left' : 'right',
+                      textAlign,
                       position: "sticky",
                       top: 0,
                       backgroundColor: headerBg,
                       color: isActive ? (isDark ? '#60a5fa' : '#2563eb') : headerColor,
                       zIndex: 10,
-                      cursor: onSort ? 'pointer' : 'default',
                       userSelect: 'none',
                     }}
                     title={onSort ? `Sort by ${getColumnLabel(col)}` : undefined}
                   >
-                    {getColumnLabel(col)}
-                    {isActive && (
-                      <span style={{ marginLeft: '4px', fontSize: '10px' }}>
-                        {sortDirection === 'asc' ? '↑' : '↓'}
-                      </span>
+                    {onSort ? (
+                      <button
+                        type="button"
+                        onClick={() => onSort(col)}
+                        style={{
+                          width: '100%',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: textAlign === 'left' ? 'flex-start' : 'flex-end',
+                          gap: '4px',
+                          padding: 0,
+                          border: 'none',
+                          background: 'transparent',
+                          color: 'inherit',
+                          font: 'inherit',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        <span>{getColumnLabel(col)}</span>
+                        {isActive && (
+                          <span style={{ fontSize: '10px' }} aria-hidden="true">
+                            {sortDirection === 'asc' ? '↑' : '↓'}
+                          </span>
+                        )}
+                      </button>
+                    ) : (
+                      <>
+                        {getColumnLabel(col)}
+                        {isActive && (
+                          <span style={{ marginLeft: '4px', fontSize: '10px' }}>
+                            {sortDirection === 'asc' ? '↑' : '↓'}
+                          </span>
+                        )}
+                      </>
                     )}
                   </th>
                 );
@@ -256,7 +286,10 @@ function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDa
             </tr>
           </thead>
           <tbody>
-            {(sortedIndices || data.map((_, i) => i)).map((originalIdx) => {
+            {((Array.isArray(sortedIndices) && sortedIndices.length === data.length)
+              ? sortedIndices
+              : data.map((_, i) => i)
+            ).map((originalIdx) => {
               const row = data[originalIdx];
               const classification = getClassification(originalIdx);
               return (

--- a/src/Plots/ComponentTable.js
+++ b/src/Plots/ComponentTable.js
@@ -66,7 +66,7 @@ const DISPLAY_COLUMNS = [
   "classification_tags",
 ];
 
-function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDark = false, isCollapsed = false, onToggleCollapse }) {
+function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDark = false, isCollapsed = false, onToggleCollapse, sortColumn = '', sortDirection = 'desc', onSort, sortedIndices }) {
   const selectedRowRef = useRef(null);
   const tableContainerRef = useRef(null);
 
@@ -217,37 +217,50 @@ function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDa
         <table style={{ width: '100%', fontSize: '13px', borderCollapse: "separate", borderSpacing: "0" }}>
           <thead>
             <tr>
-              {columns.map((col) => (
-                <th
-                  key={col}
-                  style={{
-                    padding: '12px',
-                    fontWeight: 600,
-                    whiteSpace: 'nowrap',
-                    textAlign: col === "Component" || col === "classification" || col === "classification_tags" ? 'left' : 'right',
-                    position: "sticky",
-                    top: 0,
-                    backgroundColor: headerBg,
-                    color: headerColor,
-                    zIndex: 10,
-                  }}
-                >
-                  {getColumnLabel(col)}
-                </th>
-              ))}
+              {columns.map((col) => {
+                const isActive = sortColumn === col;
+                return (
+                  <th
+                    key={col}
+                    onClick={() => onSort?.(col)}
+                    style={{
+                      padding: '12px',
+                      fontWeight: 600,
+                      whiteSpace: 'nowrap',
+                      textAlign: col === "Component" || col === "classification" || col === "classification_tags" ? 'left' : 'right',
+                      position: "sticky",
+                      top: 0,
+                      backgroundColor: headerBg,
+                      color: isActive ? (isDark ? '#60a5fa' : '#2563eb') : headerColor,
+                      zIndex: 10,
+                      cursor: onSort ? 'pointer' : 'default',
+                      userSelect: 'none',
+                    }}
+                    title={onSort ? `Sort by ${getColumnLabel(col)}` : undefined}
+                  >
+                    {getColumnLabel(col)}
+                    {isActive && (
+                      <span style={{ marginLeft: '4px', fontSize: '10px' }}>
+                        {sortDirection === 'asc' ? '↑' : '↓'}
+                      </span>
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {data.map((row, index) => {
-              const classification = getClassification(index);
+            {(sortedIndices || data.map((_, i) => i)).map((originalIdx) => {
+              const row = data[originalIdx];
+              const classification = getClassification(originalIdx);
               return (
                 <tr
-                  key={row.Component || index}
-                  ref={index === selectedIndex ? selectedRowRef : null}
-                  onClick={() => onRowClick(index)}
-                  style={getRowStyle(index)}
+                  key={row?.Component || originalIdx}
+                  ref={originalIdx === selectedIndex ? selectedRowRef : null}
+                  onClick={() => onRowClick(originalIdx)}
+                  style={getRowStyle(originalIdx)}
                   onMouseEnter={(e) => {
-                    if (index !== selectedIndex) {
+                    if (originalIdx !== selectedIndex) {
                       const cells = e.currentTarget.querySelectorAll("td");
                       cells.forEach((cell) => {
                         cell.style.backgroundColor = hoverBg;
@@ -255,7 +268,7 @@ function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDa
                     }
                   }}
                   onMouseLeave={(e) => {
-                    if (index !== selectedIndex) {
+                    if (originalIdx !== selectedIndex) {
                       const cells = e.currentTarget.querySelectorAll("td");
                       cells.forEach((cell) => {
                         cell.style.backgroundColor = "transparent";
@@ -264,7 +277,7 @@ function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDa
                   }}
                 >
                   {columns.map((col, colIndex) => {
-                    const cellStyle = getCellStyle(index, colIndex, columns.length);
+                    const cellStyle = getCellStyle(originalIdx, colIndex, columns.length);
                     if (col === "classification") {
                       return (
                         <td key={col} style={{ ...cellStyle, padding: '12px' }}>
@@ -290,7 +303,7 @@ function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDa
                         </td>
                       );
                     }
-                    const isSelected = index === selectedIndex;
+                    const isSelected = originalIdx === selectedIndex;
                     return (
                       <td
                         key={col}
@@ -299,11 +312,10 @@ function ComponentTable({ data, selectedIndex, onRowClick, classifications, isDa
                           padding: '12px',
                           textAlign: col === "Component" || col === "classification_tags" ? 'left' : 'right',
                           fontWeight: col === "Component" || col === "classification_tags" ? 500 : 400,
-                          // Use dark text on selected rows for contrast
                           color: isSelected ? '#1f2937' : textPrimary,
                         }}
                       >
-                        {formatValue(row[col], col)}
+                        {formatValue(row?.[col], col)}
                       </td>
                     );
                   })}

--- a/src/Plots/Plots.js
+++ b/src/Plots/Plots.js
@@ -59,6 +59,14 @@ function Plots({ componentData, componentFigures, originalData, mixingMatrix, ni
     return saved !== 'false'; // Default to true unless explicitly set to false
   });
 
+  // Sort column and direction for component table / keyboard navigation
+  const [sortColumn, setSortColumn] = useState(
+    () => localStorage.getItem('rica-sort-column') || ''
+  );
+  const [sortDirection, setSortDirection] = useState(
+    () => localStorage.getItem('rica-sort-direction') || 'desc'
+  );
+
   // Persist preferences to localStorage when they change
   useEffect(() => {
     localStorage.setItem('rica-keep-original-order', keepOriginalOrder.toString());
@@ -71,6 +79,14 @@ function Plots({ componentData, componentFigures, originalData, mixingMatrix, ni
   useEffect(() => {
     localStorage.setItem('rica-table-collapsed', isTableCollapsed.toString());
   }, [isTableCollapsed]);
+
+  useEffect(() => {
+    localStorage.setItem('rica-sort-column', sortColumn);
+  }, [sortColumn]);
+
+  useEffect(() => {
+    localStorage.setItem('rica-sort-direction', sortDirection);
+  }, [sortDirection]);
 
   // Interactive views (time series + FFT) require only the mixing matrix.
   // The brain viewer additionally requires the NIfTI.
@@ -257,6 +273,38 @@ function Plots({ componentData, componentFigures, originalData, mixingMatrix, ni
     return pieData.findIndex((d) => d.originalIdx === selectedIndex);
   }, [pieData, selectedIndex]);
 
+  // Navigation order for keyboard arrow keys and component table display.
+  // When a sortColumn is active, components are ordered by that metric.
+  // Otherwise falls back to pieData order (classification-grouped, variance-desc).
+  const navigationOrder = useMemo(() => {
+    if (!sortColumn || !processedData.length) return pieData;
+    const fullData = componentData?.[0] || [];
+    return [...processedData.map((d, i) => ({ ...d, originalIdx: i }))].sort((a, b) => {
+      const valA = fullData[a.originalIdx]?.[sortColumn] ?? 0;
+      const valB = fullData[b.originalIdx]?.[sortColumn] ?? 0;
+      return sortDirection === 'asc' ? valA - valB : valB - valA;
+    });
+  }, [processedData, sortColumn, sortDirection, componentData, pieData]);
+
+  const sortedIndices = useMemo(
+    () => navigationOrder.map((d) => d.originalIdx),
+    [navigationOrder]
+  );
+
+  // Handle column header click: desc → asc → clear
+  const handleSort = useCallback((col) => {
+    if (sortColumn === col) {
+      if (sortDirection === 'asc') {
+        setSortColumn('');
+      } else {
+        setSortDirection('asc');
+      }
+    } else {
+      setSortColumn(col);
+      setSortDirection('desc');
+    }
+  }, [sortColumn, sortDirection]);
+
   // Keyboard shortcuts
   useHotkeys("a", () => handleNewSelection("accepted"), [handleNewSelection]);
   useHotkeys("r", () => handleNewSelection("rejected"), [handleNewSelection]);
@@ -264,31 +312,29 @@ function Plots({ componentData, componentFigures, originalData, mixingMatrix, ni
   useHotkeys(
     "left",
     () => {
-      // Navigate using pie chart order (wraps around)
-      if (pieData.length === 0) return;
-      const currentPieIdx = pieData.findIndex((d) => d.originalIdx === selectedIndex);
-      const newPieIdx = currentPieIdx <= 0 ? pieData.length - 1 : currentPieIdx - 1;
-      const newOriginalIdx = pieData[newPieIdx].originalIdx;
+      if (navigationOrder.length === 0) return;
+      const currentIdx = navigationOrder.findIndex((d) => d.originalIdx === selectedIndex);
+      const newIdx = currentIdx <= 0 ? navigationOrder.length - 1 : currentIdx - 1;
+      const newOriginalIdx = navigationOrder[newIdx].originalIdx;
       setSelectedIndex(newOriginalIdx);
       setSelectedClassification(processedData[newOriginalIdx]?.classification || "accepted");
       findComponentImage(newOriginalIdx, processedData);
     },
-    [selectedIndex, pieData, processedData, findComponentImage]
+    [selectedIndex, navigationOrder, processedData, findComponentImage]
   );
 
   useHotkeys(
     "right",
     () => {
-      // Navigate using pie chart order (wraps around)
-      if (pieData.length === 0) return;
-      const currentPieIdx = pieData.findIndex((d) => d.originalIdx === selectedIndex);
-      const newPieIdx = currentPieIdx >= pieData.length - 1 ? 0 : currentPieIdx + 1;
-      const newOriginalIdx = pieData[newPieIdx].originalIdx;
+      if (navigationOrder.length === 0) return;
+      const currentIdx = navigationOrder.findIndex((d) => d.originalIdx === selectedIndex);
+      const newIdx = currentIdx >= navigationOrder.length - 1 ? 0 : currentIdx + 1;
+      const newOriginalIdx = navigationOrder[newIdx].originalIdx;
       setSelectedIndex(newOriginalIdx);
       setSelectedClassification(processedData[newOriginalIdx]?.classification || "accepted");
       findComponentImage(newOriginalIdx, processedData);
     },
-    [selectedIndex, pieData, processedData, findComponentImage]
+    [selectedIndex, navigationOrder, processedData, findComponentImage]
   );
 
   // Save handler
@@ -614,6 +660,10 @@ function Plots({ componentData, componentFigures, originalData, mixingMatrix, ni
         isDark={isDark}
         isCollapsed={isTableCollapsed}
         onToggleCollapse={() => setIsTableCollapsed(!isTableCollapsed)}
+        sortColumn={sortColumn}
+        sortDirection={sortDirection}
+        onSort={handleSort}
+        sortedIndices={sortedIndices}
       />
 
       {/* External Regressors Correlation Heatmap (interactive) or static figure */}

--- a/src/Plots/Plots.js
+++ b/src/Plots/Plots.js
@@ -280,15 +280,25 @@ function Plots({ componentData, componentFigures, originalData, mixingMatrix, ni
     if (!sortColumn || !processedData.length) return pieData;
     const fullData = componentData?.[0] || [];
     return [...processedData.map((d, i) => ({ ...d, originalIdx: i }))].sort((a, b) => {
-      const valA = fullData[a.originalIdx]?.[sortColumn] ?? 0;
-      const valB = fullData[b.originalIdx]?.[sortColumn] ?? 0;
+      const valA = fullData[a.originalIdx]?.[sortColumn] ?? null;
+      const valB = fullData[b.originalIdx]?.[sortColumn] ?? null;
+      if (valA === null && valB === null) return 0;
+      if (valA === null) return 1;
+      if (valB === null) return -1;
+      if (typeof valA === 'string' || typeof valB === 'string') {
+        return sortDirection === 'asc'
+          ? String(valA).localeCompare(String(valB))
+          : String(valB).localeCompare(String(valA));
+      }
       return sortDirection === 'asc' ? valA - valB : valB - valA;
     });
   }, [processedData, sortColumn, sortDirection, componentData, pieData]);
 
   const sortedIndices = useMemo(
-    () => navigationOrder.map((d) => d.originalIdx),
-    [navigationOrder]
+    () => sortColumn
+      ? navigationOrder.map((d) => d.originalIdx)
+      : processedData.map((_, i) => i),
+    [navigationOrder, sortColumn, processedData]
   );
 
   // Handle column header click: desc → asc → clear


### PR DESCRIPTION
## Summary

Closes #124

This PR adds the ability to sort components by any metric in `metrics.tsv` and loop over component figures in that order.

- **Clickable column headers** in the Component Metrics table — click a header to sort by that metric descending, click again for ascending, click a third time to clear (back to default order)
- Active sort column is highlighted in blue with a ↑/↓ direction indicator
- **Arrow-key navigation** (←/→) loops through component figures following the same sorted order
- Sort preference (column + direction) persists across page reloads via `localStorage`
- Pie chart visual order is unchanged (it remains grouped by classification)

## Changed files

- `src/Plots/ComponentTable.js` — clickable `<th>` headers with sort indicator; row rendering now iterates `sortedIndices` so rows reorder while `selectedIndex` stays anchored to original TSV positions
- `src/Plots/Plots.js` — `sortColumn`/`sortDirection` state, `navigationOrder` memo (drives both table and keyboard nav), `handleSort` callback, new props passed to `ComponentTable`

## Test plan

- [x] Load a tedana report, click the **Kappa** header → rows sort by kappa descending, ↓ appears
- [x] Click **Kappa** again → sort switches to ascending, ↑ appears
- [x] Click **Kappa** a third time → sort clears, original order restored
- [x] While sorted, press ←/→ arrow keys → figure navigation follows the sort order
- [x] Click a different column header → sort switches to that column
- [x] Reload page → sort preference persists
- [x] Clicking any table row still selects that component in all other views (scatter, pie, time series)
- [x] Pie chart visual order is unaffected by sort changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)